### PR TITLE
Fix/duplicated disks on cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fix xDisk - test resource fails when computer is part of a cluster [Issue #80](https://github.com/PowerShell/StorageDsc/issues/80)
+    Get-Disk will now be limited to the disks returned by Get-PhysicalDisk
+
 ## 4.7.0.0
 
 - DiskAccessPath:

--- a/DSCResources/MSFTDSC_Disk/MSFTDSC_Disk.psm1
+++ b/DSCResources/MSFTDSC_Disk/MSFTDSC_Disk.psm1
@@ -797,7 +797,7 @@ function Test-TargetResource
         }
     } # if
 
-    $partition = $partition = Get-PhysicalDisk | Get-Disk | Get-Partition `
+    $partition = Get-PhysicalDisk | Get-Disk | Get-Partition `
                     Where-Object -Property DriveLetter -EQ -Value $DriveLetter`
                     -ErrorAction SilentlyContinue
 

--- a/DSCResources/MSFTDSC_Disk/MSFTDSC_Disk.psm1
+++ b/DSCResources/MSFTDSC_Disk/MSFTDSC_Disk.psm1
@@ -125,13 +125,13 @@ function Get-TargetResource
         -DiskId $DiskId `
         -DiskIdType $DiskIdType
 
-    $partition = Get-Partition `
-        -DriveLetter $DriveLetter `
-        -ErrorAction SilentlyContinue
+    $partition = Get-PhysicalDisk | Get-Disk | Get-Partition `
+                    Where-Object -Property DriveLetter -EQ -Value $DriveLetter`
+                    -ErrorAction SilentlyContinue
 
-    $volume = Get-Volume `
-        -DriveLetter $DriveLetter `
-        -ErrorAction SilentlyContinue
+    $volume = Get-PhysicalDisk | Get-Disk | Get-Partition | Get-Volume `
+                    Where-Object -Property DriveLetter -EQ -Value $DriveLetter `
+                    -ErrorAction SilentlyContinue
 
     $blockSize = (Get-CimInstance `
             -Query "SELECT BlockSize from Win32_Volume WHERE DriveLetter = '$($DriveLetter):'" `
@@ -797,9 +797,9 @@ function Test-TargetResource
         }
     } # if
 
-    $partition = Get-Partition `
-        -DriveLetter $DriveLetter `
-        -ErrorAction SilentlyContinue
+    $partition = $partition = Get-PhysicalDisk | Get-Disk | Get-Partition `
+                    Where-Object -Property DriveLetter -EQ -Value $DriveLetter`
+                    -ErrorAction SilentlyContinue
 
     if ($partition.DriveLetter -ne $DriveLetter)
     {
@@ -868,9 +868,9 @@ function Test-TargetResource
     } # if
 
     # Get the volume so the properties can be checked
-    $volume = Get-Volume `
-        -DriveLetter $DriveLetter `
-        -ErrorAction SilentlyContinue
+    $volume = Get-PhysicalDisk | Get-Disk | Get-Partition | Get-Volume `
+                    Where-Object -Property DriveLetter -EQ -Value $DriveLetter `
+                    -ErrorAction SilentlyContinue
 
     if ($PSBoundParameters.ContainsKey('FSFormat'))
     {

--- a/DSCResources/MSFTDSC_Disk/MSFTDSC_Disk.psm1
+++ b/DSCResources/MSFTDSC_Disk/MSFTDSC_Disk.psm1
@@ -125,11 +125,11 @@ function Get-TargetResource
         -DiskId $DiskId `
         -DiskIdType $DiskIdType
 
-    $partition = Get-PhysicalDisk | Get-Disk | Get-Partition | `
+    $partition = $disk | Get-Partition | `
                     Where-Object -Property DriveLetter -EQ -Value $DriveLetter `
                     -ErrorAction SilentlyContinue
 
-    $volume = Get-PhysicalDisk | Get-Disk | Get-Partition | Get-Volume | `
+    $volume = $partition | Get-Volume | `
                     Where-Object -Property DriveLetter -EQ -Value $DriveLetter `
                     -ErrorAction SilentlyContinue
 

--- a/DSCResources/MSFTDSC_Disk/MSFTDSC_Disk.psm1
+++ b/DSCResources/MSFTDSC_Disk/MSFTDSC_Disk.psm1
@@ -125,11 +125,11 @@ function Get-TargetResource
         -DiskId $DiskId `
         -DiskIdType $DiskIdType
 
-    $partition = Get-PhysicalDisk | Get-Disk | Get-Partition `
+    $partition = Get-PhysicalDisk | Get-Disk | Get-Partition | `
                     Where-Object -Property DriveLetter -EQ -Value $DriveLetter`
                     -ErrorAction SilentlyContinue
 
-    $volume = Get-PhysicalDisk | Get-Disk | Get-Partition | Get-Volume `
+    $volume = Get-PhysicalDisk | Get-Disk | Get-Partition | Get-Volume | `
                     Where-Object -Property DriveLetter -EQ -Value $DriveLetter `
                     -ErrorAction SilentlyContinue
 
@@ -868,7 +868,7 @@ function Test-TargetResource
     } # if
 
     # Get the volume so the properties can be checked
-    $volume = Get-PhysicalDisk | Get-Disk | Get-Partition | Get-Volume `
+    $volume = Get-PhysicalDisk | Get-Disk | Get-Partition | Get-Volume | `
                     Where-Object -Property DriveLetter -EQ -Value $DriveLetter `
                     -ErrorAction SilentlyContinue
 

--- a/DSCResources/MSFTDSC_Disk/MSFTDSC_Disk.psm1
+++ b/DSCResources/MSFTDSC_Disk/MSFTDSC_Disk.psm1
@@ -126,7 +126,7 @@ function Get-TargetResource
         -DiskIdType $DiskIdType
 
     $partition = Get-PhysicalDisk | Get-Disk | Get-Partition | `
-                    Where-Object -Property DriveLetter -EQ -Value $DriveLetter`
+                    Where-Object -Property DriveLetter -EQ -Value $DriveLetter `
                     -ErrorAction SilentlyContinue
 
     $volume = Get-PhysicalDisk | Get-Disk | Get-Partition | Get-Volume | `
@@ -798,7 +798,7 @@ function Test-TargetResource
     } # if
 
     $partition = Get-PhysicalDisk | Get-Disk | Get-Partition | `
-                    Where-Object -Property DriveLetter -EQ -Value $DriveLetter`
+                    Where-Object -Property DriveLetter -EQ -Value $DriveLetter `
                     -ErrorAction SilentlyContinue
 
     if ($partition.DriveLetter -ne $DriveLetter)

--- a/DSCResources/MSFTDSC_Disk/MSFTDSC_Disk.psm1
+++ b/DSCResources/MSFTDSC_Disk/MSFTDSC_Disk.psm1
@@ -797,7 +797,7 @@ function Test-TargetResource
         }
     } # if
 
-    $partition = Get-PhysicalDisk | Get-Disk | Get-Partition `
+    $partition = Get-PhysicalDisk | Get-Disk | Get-Partition | `
                     Where-Object -Property DriveLetter -EQ -Value $DriveLetter`
                     -ErrorAction SilentlyContinue
 

--- a/Modules/StorageDsc.Common/StorageDsc.Common.psm1
+++ b/Modules/StorageDsc.Common/StorageDsc.Common.psm1
@@ -138,22 +138,9 @@ function Get-DiskByIdentifier
         $DiskIdType = 'Number'
     )
 
-    if ($DiskIdType -eq 'Guid')
-    {
-        # The Disk Id requested uses a Guid so have to get all disks and filter
-        $disk = Get-Disk -ErrorAction SilentlyContinue |
-            Where-Object -Property Guid -EQ $DiskId
-    }
-    else
-    {
-        $diskIdParameter = @{
-            $DiskIdType = $DiskId
-        }
-
-        $disk = Get-Disk `
-            @diskIdParameter `
-            -ErrorAction SilentlyContinue
-    }
+    $disk = Get-PhysicalDisk | Get-Disk | `
+                Where-Object -Property $DiskIdType -EQ -Value $DiskId `
+                -ErrorAction SilentlyContinue
 
     return $disk
 } # end function Get-DiskByIdentifier

--- a/Modules/StorageDsc.Common/StorageDsc.Common.psm1
+++ b/Modules/StorageDsc.Common/StorageDsc.Common.psm1
@@ -141,11 +141,11 @@ function Get-DiskByIdentifier
     $physicalDisks = Get-PhysicalDisk
 
     $disk = Get-Disk | `
-                Where-Object -Property UniqueId -EQ $physicalDisks.UniqueId | `
+                Where-Object -Property 'UniqueId' -In $physicalDisks.UniqueId | `
                 Where-Object -Property $DiskIdType -EQ -Value $DiskId `
                 -ErrorAction SilentlyContinue
 
-    return $disk | Select-Object -First 1
+    return $disk
 } # end function Get-DiskByIdentifier
 
 <#

--- a/Modules/StorageDsc.Common/StorageDsc.Common.psm1
+++ b/Modules/StorageDsc.Common/StorageDsc.Common.psm1
@@ -138,11 +138,14 @@ function Get-DiskByIdentifier
         $DiskIdType = 'Number'
     )
 
-    $disk = Get-PhysicalDisk | Get-Disk | `
+    $physicalDisks = Get-PhysicalDisk
+
+    $disk = Get-Disk | `
+                Where-Object -Property UniqueId -EQ $physicalDisks.UniqueId | `
                 Where-Object -Property $DiskIdType -EQ -Value $DiskId `
                 -ErrorAction SilentlyContinue
 
-    return $disk
+    return $disk | Select-Object -First 1
 } # end function Get-DiskByIdentifier
 
 <#

--- a/Tests/Unit/StorageDsc.Common.Tests.ps1
+++ b/Tests/Unit/StorageDsc.Common.Tests.ps1
@@ -47,6 +47,19 @@ try
             $UniqueId
         )
     }
+
+    function Get-PhysicalDisk
+    {
+        [CmdletBinding()]
+        Param
+        (
+            [System.UInt32]
+            $Number,
+
+            [System.String]
+            $UniqueId
+        )
+    }
     #endregion
 
     #region Function Assert-DriveLetterValid
@@ -161,6 +174,8 @@ try
         $testDiskNumber = 10
         $testDiskUniqueId = 'DiskUniqueId'
         $testDiskGuid = [Guid]::NewGuid().ToString()
+        $testPhysicalDiskUsage = 1
+
 
         $mockedDisk = [pscustomobject] @{
             Number   = $testDiskNumber
@@ -168,11 +183,25 @@ try
             Guid     = $testDiskGuid
         }
 
+        $mockedPhysicalDisk = [pscustomobject] @{
+            Number            = $testDiskNumber
+            UniqueId          = $testDiskUniqueId
+            Guid              = $testDiskGuid
+            PhysicalDiskUsage = $testPhysicalDiskUsage
+        }
+
         Describe 'StorageDsc.Common\Get-DiskByIdentifier' {
             Context 'Disk exists that matches the specified Disk Number' {
                 Mock `
                     -CommandName Get-Disk `
                     -MockWith { $mockedDisk } `
+                    -ModuleName StorageDsc.Common `
+                    -ParameterFilter { $Number -eq $testDiskNumber } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-PhysicalDisk `
+                    -MockWith { $mockedPhysicalDisk } `
                     -ModuleName StorageDsc.Common `
                     -ParameterFilter { $Number -eq $testDiskNumber } `
                     -Verifiable
@@ -185,6 +214,12 @@ try
                     Assert-VerifiableMock
                     Assert-MockCalled `
                         -CommandName Get-Disk `
+                        -ModuleName StorageDsc.Common `
+                        -ParameterFilter { $Number -eq $testDiskNumber } `
+                        -Exactly `
+                        -Times 1
+                    Assert-MockCalled `
+                        -CommandName Get-PhysicalDisk `
                         -ModuleName StorageDsc.Common `
                         -ParameterFilter { $Number -eq $testDiskNumber } `
                         -Exactly `
@@ -207,6 +242,12 @@ try
                     Assert-VerifiableMock
                     Assert-MockCalled `
                         -CommandName Get-Disk `
+                        -ModuleName StorageDsc.Common `
+                        -ParameterFilter { $Number -eq $testDiskNumber } `
+                        -Exactly `
+                        -Times 1
+                    Assert-MockCalled `
+                        -CommandName Get-PhysicalDisk `
                         -ModuleName StorageDsc.Common `
                         -ParameterFilter { $Number -eq $testDiskNumber } `
                         -Exactly `
@@ -234,6 +275,12 @@ try
                         -ParameterFilter { $UniqueId -eq $testDiskUniqueId } `
                         -Exactly `
                         -Times 1
+                    Assert-MockCalled `
+                        -CommandName Get-PhysicalDisk `
+                        -ModuleName StorageDsc.Common `
+                        -ParameterFilter { $UniqueId -eq $testDiskUniqueId } `
+                        -Exactly `
+                        -Times 1
                 }
             }
 
@@ -256,6 +303,12 @@ try
                         -ParameterFilter { $UniqueId -eq $testDiskUniqueId } `
                         -Exactly `
                         -Times 1
+                    Assert-MockCalled `
+                        -CommandName Get-PhysicalDisk `
+                        -ModuleName StorageDsc.Common `
+                        -ParameterFilter { $UniqueId -eq $testDiskUniqueId } `
+                        -Exactly `
+                        -Times 1
                 }
             }
 
@@ -263,6 +316,12 @@ try
                 Mock `
                     -CommandName Get-Disk `
                     -MockWith { $mockedDisk } `
+                    -ModuleName StorageDsc.Common `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-PhysicalDisk `
+                    -MockWith { $mockedPhysicalDisk } `
                     -ModuleName StorageDsc.Common `
                     -Verifiable
 
@@ -277,6 +336,11 @@ try
                         -ModuleName StorageDsc.Common `
                         -Exactly `
                         -Times 1
+                    Assert-MockCalled `
+                        -CommandName Get-PhysicalDisk `
+                        -ModuleName StorageDsc.Common `
+                        -Exactly `
+                        -Times 1
                 }
             }
 
@@ -285,7 +349,10 @@ try
                     -CommandName Get-Disk `
                     -ModuleName StorageDsc.Common `
                     -Verifiable
-
+                Mock `
+                    -CommandName Get-PhysicalDisk `
+                    -ModuleName StorageDsc.Common `
+                    -Verifiable
                 It "Should return Disk with Disk Guid $testDiskGuid" {
                     Get-DiskByIdentifier -DiskId $testDiskGuid -DiskIdType 'Guid' | Should -BeNullOrEmpty
                 }
@@ -294,6 +361,11 @@ try
                     Assert-VerifiableMock
                     Assert-MockCalled `
                         -CommandName Get-Disk `
+                        -ModuleName StorageDsc.Common `
+                        -Exactly `
+                        -Times 1
+                    Assert-MockCalled `
+                        -CommandName Get-PhysicalDisk `
                         -ModuleName StorageDsc.Common `
                         -Exactly `
                         -Times 1
@@ -327,7 +399,7 @@ try
             Context 'Contains multiple access paths where none are local' {
                 It 'Should return $false' {
                     Test-AccessPathAssignedToLocal `
-                        -AccessPath @('\\?\Volume{905551f3-33a5-421d-ac24-c993fbfb3184}\','\\?\Volume{99cf0194-ac45-4a23-b36e-3e458158a63e}\') | Should -Be $false
+                        -AccessPath @('\\?\Volume{905551f3-33a5-421d-ac24-c993fbfb3184}\', '\\?\Volume{99cf0194-ac45-4a23-b36e-3e458158a63e}\') | Should -Be $false
                 }
             }
         }

--- a/Tests/Unit/StorageDsc.Common.Tests.ps1
+++ b/Tests/Unit/StorageDsc.Common.Tests.ps1
@@ -172,10 +172,11 @@ try
     #region Function Get-DiskByIdentifier
     InModuleScope $script:ModuleName {
         $testDiskNumber = 10
+        $testDiskNumberFail = 20
         $testDiskUniqueId = 'DiskUniqueId'
+        $testDiskUniqueIdFail = 'FailToGetUniqueId'
         $testDiskGuid = [Guid]::NewGuid().ToString()
-        $testPhysicalDiskUsage = 1
-
+        $testDiskGuidFail = [Guid]::NewGuid().ToString()
 
         $mockedDisk = [pscustomobject] @{
             Number   = $testDiskNumber
@@ -184,160 +185,99 @@ try
         }
 
         $mockedPhysicalDisk = [pscustomobject] @{
-            Number            = $testDiskNumber
-            UniqueId          = $testDiskUniqueId
-            Guid              = $testDiskGuid
-            PhysicalDiskUsage = $testPhysicalDiskUsage
+            UniqueId = $testDiskUniqueId
         }
 
         Describe 'StorageDsc.Common\Get-DiskByIdentifier' {
-            Context 'Disk exists that matches the specified Disk Number' {
-                Mock `
-                    -CommandName Get-Disk `
-                    -MockWith { $mockedDisk } `
-                    -ModuleName StorageDsc.Common `
-                    -ParameterFilter { $Number -eq $testDiskNumber } `
-                    -Verifiable
 
+            BeforeEach {
                 Mock `
                     -CommandName Get-PhysicalDisk `
                     -MockWith { $mockedPhysicalDisk } `
                     -ModuleName StorageDsc.Common `
-                    -ParameterFilter { $Number -eq $testDiskNumber } `
+                    -RemoveParameterType Usage, HealthStatus
+
+                Mock `
+                    -CommandName Get-Disk `
+                    -MockWith { $mockedDisk } `
+                    -ModuleName StorageDsc.Common `
                     -Verifiable
+            }
+
+            Context 'Disk exists that matches the specified Disk Number' {
 
                 It "Should return Disk with Disk Number $testDiskNumber" {
                     (Get-DiskByIdentifier -DiskId $testDiskNumber).Number | Should -Be $testDiskNumber
                 }
 
                 It 'Should call expected mocks' {
-                    Assert-VerifiableMock
+
                     Assert-MockCalled `
                         -CommandName Get-Disk `
                         -ModuleName StorageDsc.Common `
-                        -ParameterFilter { $Number -eq $testDiskNumber } `
-                        -Exactly `
-                        -Times 1
-                    Assert-MockCalled `
-                        -CommandName Get-PhysicalDisk `
-                        -ModuleName StorageDsc.Common `
-                        -ParameterFilter { $Number -eq $testDiskNumber } `
                         -Exactly `
                         -Times 1
                 }
             }
 
             Context 'Disk does not exist that matches the specified Disk Number' {
-                Mock `
-                    -CommandName Get-Disk `
-                    -ModuleName StorageDsc.Common `
-                    -ParameterFilter { $Number -eq $testDiskNumber } `
-                    -Verifiable
 
-                It "Should return Disk with Disk Number $testDiskNumber" {
-                    Get-DiskByIdentifier -DiskId $testDiskNumber | Should -BeNullOrEmpty
+                It "Should not return Disk with Disk Number $testDiskNumber when searching for $testDiskNumberFail" {
+                    Get-DiskByIdentifier -DiskId $testDiskNumberFail | Should -BeNullOrEmpty
                 }
 
                 It 'Should call expected mocks' {
-                    Assert-VerifiableMock
+
                     Assert-MockCalled `
                         -CommandName Get-Disk `
                         -ModuleName StorageDsc.Common `
-                        -ParameterFilter { $Number -eq $testDiskNumber } `
-                        -Exactly `
-                        -Times 1
-                    Assert-MockCalled `
-                        -CommandName Get-PhysicalDisk `
-                        -ModuleName StorageDsc.Common `
-                        -ParameterFilter { $Number -eq $testDiskNumber } `
                         -Exactly `
                         -Times 1
                 }
             }
 
             Context 'Disk exists that matches the specified Disk Unique Id' {
-                Mock `
-                    -CommandName Get-Disk `
-                    -MockWith { $mockedDisk } `
-                    -ModuleName StorageDsc.Common `
-                    -ParameterFilter { $UniqueId -eq $testDiskUniqueId } `
-                    -Verifiable
 
                 It "Should return Disk with Disk Unique Id $testDiskUniqueId" {
                     (Get-DiskByIdentifier -DiskId $testDiskUniqueId -DiskIdType 'UniqueId').UniqueId | Should -Be $testDiskUniqueId
                 }
 
                 It 'Should call expected mocks' {
-                    Assert-VerifiableMock
+
                     Assert-MockCalled `
                         -CommandName Get-Disk `
                         -ModuleName StorageDsc.Common `
-                        -ParameterFilter { $UniqueId -eq $testDiskUniqueId } `
-                        -Exactly `
-                        -Times 1
-                    Assert-MockCalled `
-                        -CommandName Get-PhysicalDisk `
-                        -ModuleName StorageDsc.Common `
-                        -ParameterFilter { $UniqueId -eq $testDiskUniqueId } `
                         -Exactly `
                         -Times 1
                 }
             }
 
             Context 'Disk does not exist that matches the specified Disk Unique Id' {
-                Mock `
-                    -CommandName Get-Disk `
-                    -ModuleName StorageDsc.Common `
-                    -ParameterFilter { $UniqueId -eq $testDiskUniqueId } `
-                    -Verifiable
 
-                It "Should return Disk with Disk Unique Id $testDiskUniqueId" {
-                    Get-DiskByIdentifier -DiskId $testDiskUniqueId -DiskIdType 'UniqueId' | Should -BeNullOrEmpty
+                It "Should not return Disk with Disk Unique Id $testDiskUniqueId when searching for $testDiskUniqueIdFail" {
+                    Get-DiskByIdentifier -DiskId $testDiskUniqueIdFail -DiskIdType 'UniqueId' | Should -BeNullOrEmpty
                 }
 
                 It 'Should call expected mocks' {
-                    Assert-VerifiableMock
+
                     Assert-MockCalled `
                         -CommandName Get-Disk `
                         -ModuleName StorageDsc.Common `
-                        -ParameterFilter { $UniqueId -eq $testDiskUniqueId } `
-                        -Exactly `
-                        -Times 1
-                    Assert-MockCalled `
-                        -CommandName Get-PhysicalDisk `
-                        -ModuleName StorageDsc.Common `
-                        -ParameterFilter { $UniqueId -eq $testDiskUniqueId } `
                         -Exactly `
                         -Times 1
                 }
             }
 
             Context 'Disk exists that matches the specified Disk Guid' {
-                Mock `
-                    -CommandName Get-Disk `
-                    -MockWith { $mockedDisk } `
-                    -ModuleName StorageDsc.Common `
-                    -Verifiable
-
-                Mock `
-                    -CommandName Get-PhysicalDisk `
-                    -MockWith { $mockedPhysicalDisk } `
-                    -ModuleName StorageDsc.Common `
-                    -Verifiable
 
                 It "Should return Disk with Disk Guid $testDiskGuid" {
                     (Get-DiskByIdentifier -DiskId $testDiskGuid -DiskIdType 'Guid').Guid | Should -Be $testDiskGuid
                 }
 
                 It 'Should call expected mocks' {
-                    Assert-VerifiableMock
+
                     Assert-MockCalled `
                         -CommandName Get-Disk `
-                        -ModuleName StorageDsc.Common `
-                        -Exactly `
-                        -Times 1
-                    Assert-MockCalled `
-                        -CommandName Get-PhysicalDisk `
                         -ModuleName StorageDsc.Common `
                         -Exactly `
                         -Times 1
@@ -345,27 +285,15 @@ try
             }
 
             Context 'Disk does not exist that matches the specified Disk Guid' {
-                Mock `
-                    -CommandName Get-Disk `
-                    -ModuleName StorageDsc.Common `
-                    -Verifiable
-                Mock `
-                    -CommandName Get-PhysicalDisk `
-                    -ModuleName StorageDsc.Common `
-                    -Verifiable
-                It "Should return Disk with Disk Guid $testDiskGuid" {
-                    Get-DiskByIdentifier -DiskId $testDiskGuid -DiskIdType 'Guid' | Should -BeNullOrEmpty
+
+                It "Should not return Disk with Disk Guid $testDiskGuid when searching for $testDiskGuidFail" {
+                    Get-DiskByIdentifier -DiskId $testDiskGuidFail -DiskIdType 'Guid' | Should -BeNullOrEmpty
                 }
 
                 It 'Should call expected mocks' {
-                    Assert-VerifiableMock
+
                     Assert-MockCalled `
                         -CommandName Get-Disk `
-                        -ModuleName StorageDsc.Common `
-                        -Exactly `
-                        -Times 1
-                    Assert-MockCalled `
-                        -CommandName Get-PhysicalDisk `
                         -ModuleName StorageDsc.Common `
                         -Exactly `
                         -Times 1


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes the issue where Get-Disk on Windows Failover Cluster node returns all disks within the cluster, resulting in duplicated volumes and partitions.

#### This Pull Request (PR) fixes the following issues
Fixes #80

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md in the resource folder.
- [x] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
